### PR TITLE
fix(dgs_corpus): extract english text from ELAN files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ print(packages)
 setup(
     name="sign-language-datasets",
     packages=packages,
-    version="0.0.5",
+    version="0.0.6",
     description="TFDS Datasets for sign language",
     author="Amit Moryossef",
     author_email="amitmoryossef@gmail.com",

--- a/sign_language_datasets/datasets/dgs_corpus/dgs_utils.py
+++ b/sign_language_datasets/datasets/dgs_corpus/dgs_utils.py
@@ -38,7 +38,7 @@ def get_elan_sentences(elan_path: str):
             sentence = {"participant": participant, "start": timeslots[s], "end": timeslots[e], "german": val}
 
             # Add English sentence
-            english_sentence = [val for (s2, e2, val2, _) in english_text if s == s2 and e == e2]
+            english_sentence = [val2 for (s2, e2, val2, _) in english_text if s == s2 and e == e2]
             sentence["english"] = english_sentence[0] if len(english_sentence) > 0 else None
 
             # Add glosses


### PR DESCRIPTION
Small fix to extract English sentences from the DGS ELAN files

Current behaviour:

```python
config = SignDatasetConfig(name="only-annotations", version="1.0.0", include_video=False, include_pose=None)
dgs_corpus = tfds.load('dgs_corpus', builder_kwargs=dict(config=config))

from sign_language_datasets.datasets.dgs_corpus.dgs_utils import get_elan_sentences

for datum in itertools.islice(dgs_corpus["train"], 0, 10):
  elan_path = datum["paths"]["eaf"].numpy().decode('utf-8')
  sentences =  get_elan_sentences(elan_path)

  try:
    sentence = next(sentences)
    print(sentence["german"])
    print(sentence["english"])
    print()
  except StopIteration:
    pass
```

**Output**

```
Die Koffer waren fertig gepackt und standen bereit.
Die Koffer waren fertig gepackt und standen bereit.

Ich war viel mit dem Theater unterwegs, mit dem Deutschen Gehörlosentheater. Wir waren überall an verschiedensten Standorten in Deutschland.
Ich war viel mit dem Theater unterwegs, mit dem Deutschen Gehörlosentheater. Wir waren überall an verschiedensten Standorten in Deutschland.

Ja, so war es.
Ja, so war es.

Ja, in Bulgarien, ach nein Bukarest.
Ja, in Bulgarien, ach nein Bukarest.

Ich/ Wie bitte?
Ich/ Wie bitte?

Soll ich anfangen, zu gebärden und ihr das zu erzählen?
Soll ich anfangen, zu gebärden und ihr das zu erzählen?
```