### PR TITLE
Fix dgs video loading and split

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ global-include *.poseheader
 global-include *.tsv
 global-include *.png
 global-include *.ttf
+global-include *.json

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ print(packages)
 setup(
     name="sign-language-datasets",
     packages=packages,
-    version="0.0.13",
+    version="0.0.14",
     description="TFDS Datasets for sign language",
     author="Amit Moryossef",
     author_email="amitmoryossef@gmail.com",

--- a/sign_language_datasets/datasets/dgs_corpus/dgs_corpus.py
+++ b/sign_language_datasets/datasets/dgs_corpus/dgs_corpus.py
@@ -250,7 +250,16 @@ class DgsCorpus(tfds.core.GeneratorBasedBuilder):
             }
 
             if self._builder_config.include_video:
-                videos = {t: str(datum["video_" + t]) if ("video_" + t) in datum else "" for t in ["a", "b", "c"]}
+                videos = {}
+                for participant in ["a", "b", "c"]:
+                    video_key = "video_" + participant
+
+                    if video_key not in datum.keys() or datum[video_key] is None:
+                        video = ""
+                    else:
+                        video = str(datum[video_key])
+
+                    videos[participant] = video
 
                 # make sure that the video fps is as expected
 


### PR DESCRIPTION
Fixes the dgs loader when `include_video=True` (this never worked, I just did not check carefully I think).

Also fixes loading a document split (include all relevant files in the pip packaging) 